### PR TITLE
Use internal buffer for vecorized writing and do not close IO after writing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.cov
 *.jl.mem
 /docs/build/
+Manifest.toml

--- a/src/io.jl
+++ b/src/io.jl
@@ -104,8 +104,9 @@ function Base.write(io::IO, d::MRCData; compress=:none, unit_vsize=4096, buffer:
     unit_vsize = div(unit_vsize, sizeof(T))
     if buffer === nothing
         buffer = Vector{T}(undef, unit_vsize)
+    elseif !(buffer isa Vector{T})
+        throw(ArgumentError("`buffer` must be `nothing` or a `Vector{$T}`, but `$(typeof(buffer))` was provided"))
     end
-    buffer::Vector{T}
     # If `buffer` was provided as a parameter then `unit_vsize` is redundant and
     # we must make sure that it matches `buffer`.
     unit_vsize = length(buffer)

--- a/src/io.jl
+++ b/src/io.jl
@@ -128,7 +128,7 @@ function Base.write(fn::AbstractString, object::T; compress=:auto, kwargs...) wh
         compress = checkextension(fn)
     end
     return open(fn; write=true) do io
-        return write(io, object; compress, kwargs...)
+        return write(io, object; compress=compress, kwargs...)
     end
 end
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -74,8 +74,8 @@ function read_mmap(path::AbstractString, T::Type{MRCData})
 end
 
 """
-    write(io::IO, ::MRCData; compress = :none, unit_vsize = 4096, buffer = nothing)
-    write(fn::AbstractString, ::MRCData; compress = :auto, unit_vsize = 4096, buffer = nothing)
+    write(io::IO, ::MRCData; compress = :none, buffer_size = 4096, buffer = nothing)
+    write(fn::AbstractString, ::MRCData; compress = :auto, buffer_size = 4096, buffer = nothing)
 
 Write an instance of [`MRCData`](@ref) to an IO stream or new file.
 Use `compress` to specify the compression with the following options:
@@ -89,7 +89,7 @@ The parameter `buffer_size` specifies the size (in bytes) of an intermediate
 buffer that is used to speed up the writing by utilizing vectorized writes.
 
 You can also directly provide a preallocated buffer as a `Vector`.
-In that case, `unit_vsize` has no effect.
+In that case, `buffer_size` has no effect.
 Note that `eltype(buffer)` must match the data type of the MRC data.
 """
 write(::Any, ::MRCData)

--- a/src/io.jl
+++ b/src/io.jl
@@ -107,7 +107,7 @@ function Base.write(io::IO, d::MRCData; compress=:none, unit_vsize=4096, buffer:
     end
     buffer::Vector{T}
     # If `buffer` was provided as a parameter then `unit_vsize` is redundant and
-    # we must make sure that it matches buffer.
+    # we must make sure that it matches `buffer`.
     unit_vsize = length(buffer)
     vlen = length(data)
     vrem = vlen % unit_vsize
@@ -119,7 +119,8 @@ function Base.write(io::IO, d::MRCData; compress=:none, unit_vsize=4096, buffer:
         @inbounds @views buffer .= fswap.(T.(data[i:i + unit_vsize - 1]))
         @inbounds sz += write(newio, buffer)
     end
-    close(newio)
+    write(newio, TranscodingStreams.TOKEN_END)
+    flush(newio)
     return sz
 end
 function Base.write(fn::AbstractString, object::T; compress=:auto, kwargs...) where {T<:Union{MRCData}}

--- a/src/io.jl
+++ b/src/io.jl
@@ -93,7 +93,13 @@ In that case, `unit_vsize` has no effect.
 Note that `eltype(buffer)` must match the data type of the MRC data.
 """
 write(::Any, ::MRCData)
-function Base.write(io::IO, d::MRCData; compress=:none, buffer_size=4096, buffer::Union{Nothing, Vector}=nothing)
+function Base.write(
+    io::IO,
+    d::MRCData;
+    compress=:none,
+    buffer_size=4096,
+    buffer::Union{Nothing,Vector}=nothing,
+)
     newio = compressstream(io, compress)
     h = header(d)
     sz = write(newio, h)
@@ -105,7 +111,11 @@ function Base.write(io::IO, d::MRCData; compress=:none, buffer_size=4096, buffer
     if buffer === nothing
         buffer = Vector{T}(undef, buffer_size)
     elseif !(buffer isa Vector{T})
-        throw(ArgumentError("`buffer` must be `nothing` or a `Vector{$T}`, but `$(typeof(buffer))` was provided"))
+        throw(
+            ArgumentError(
+                "`buffer` must be `nothing` or a `Vector{$T}`, but `$(typeof(buffer))` was provided",
+            ),
+        )
     end
     # If `buffer` was provided as a parameter then `buffer_size` is redundant and
     # we must make sure that it matches `buffer`.
@@ -117,8 +127,8 @@ function Base.write(io::IO, d::MRCData; compress=:none, buffer_size=4096, buffer
             buffer[1:vrem] .= fswap.(T.(data[1:vrem]))
             sz += write(newio, buffer[1:vrem])
         end
-        for i in vrem + 1:buffer_size:vlen
-            buffer .= fswap.(T.(data[i:i + buffer_size - 1]))
+        for i in (vrem + 1):buffer_size:vlen
+            buffer .= fswap.(T.(data[i:(i + buffer_size - 1)]))
             sz += write(newio, buffer)
         end
     end
@@ -126,7 +136,9 @@ function Base.write(io::IO, d::MRCData; compress=:none, buffer_size=4096, buffer
     flush(newio)
     return sz
 end
-function Base.write(fn::AbstractString, object::T; compress=:auto, kwargs...) where {T<:Union{MRCData}}
+function Base.write(
+    fn::AbstractString, object::T; compress=:auto, kwargs...
+) where {T<:Union{MRCData}}
     if compress == :auto
         compress = checkextension(fn)
     end

--- a/src/io.jl
+++ b/src/io.jl
@@ -102,7 +102,7 @@ function Base.write(io::IO, d::MRCData; compress=:none, unit_vsize=4096, buffer:
     data = parent(d)
     fswap = bswapfromh(h.machst)
     unit_vsize = div(unit_vsize, sizeof(T))
-    if isnothing(buffer)
+    if buffer === nothing
         buffer = Vector{T}(undef, unit_vsize)
     end
     buffer::Vector{T}

--- a/test/header.jl
+++ b/test/header.jl
@@ -128,11 +128,11 @@ end
     @test MRC.entrytobytes(:map, "abc") == [0x61, 0x62, 0x63, 0x00]
     @test MRC.entrytobytes(:map, "abcde") == [0x61, 0x62, 0x63, 0x64]
     @test MRC.entrytobytes(:label, ("abcd", ntuple(_ -> "", 9)...))[1:80] ==
-          [0x61; 0x62; 0x63; 0x64; zeros(UInt8, 76)]
+        [0x61; 0x62; 0x63; 0x64; zeros(UInt8, 76)]
     @test MRC.entrytobytes(:testfloat, Float32(3)) == reinterpret(UInt8, [Float32(3)])
     @test MRC.entrytobytes(:testint, Int32(3)) == reinterpret(UInt8, [Int32(3)])
     @test MRC.entrytobytes(:testuintbool, (0x01, 0x02, 0x03, 0x04)) ==
-          [0x01, 0x02, 0x03, 0x04]
+        [0x01, 0x02, 0x03, 0x04]
 end
 
 @testset "fieldoffsets" begin

--- a/test/io.jl
+++ b/test/io.jl
@@ -43,7 +43,8 @@
             @test h.machst === (0x44, 0x41, 0x0, 0x0)
             @test h.rms === Float32(0.15705723)
             @test h.nlabl === Int32(1)
-            @test h.label == ("::::EMDATABANK.org::::EMD-3001::::", "", "", "", "", "", "", "", "", "")
+            @test h.label ==
+                ("::::EMDATABANK.org::::EMD-3001::::", "", "", "", "", "", "", "", "", "")
         end
 
         @testset "emd3197.map" begin
@@ -89,7 +90,8 @@
             @test h.machst === (0x44, 0x41, 0x0, 0x0)
             @test h.rms === Float32(2.399953)
             @test h.nlabl === Int32(1)
-            @test h.label == ("::::EMDATABANK.org::::EMD-3197::::", "", "", "", "", "", "", "", "", "")
+            @test h.label ==
+                ("::::EMDATABANK.org::::EMD-3197::::", "", "", "", "", "", "", "", "", "")
         end
     end
 end
@@ -102,7 +104,7 @@ end
         for buffer_size in buffer_sizes
             @testset "buffer size: $buffer_size" begin
                 # no preallocation
-                io = IOBuffer(read = true, write = true)
+                io = IOBuffer(; read=true, write=true)
                 write(io, emd3001; buffer_size=buffer_size)
                 closewrite(io)
                 seekstart(io)
@@ -110,7 +112,7 @@ end
                 close(io)
 
                 # with preallocation
-                io = IOBuffer(read = true, write = true)
+                io = IOBuffer(; read=true, write=true)
                 buffer = Vector{Float32}(undef, buffer_size)
                 write(io, emd3001; buffer=buffer)
                 closewrite(io)

--- a/test/io.jl
+++ b/test/io.jl
@@ -103,7 +103,7 @@ end
             @testset "buffer size: $buffer_size" begin
                 # no preallocation
                 io = IOBuffer(read = true, write = true)
-                mem_non_prealloc = @allocated write(io, emd3001; unit_vsize = buffer_size)
+                write(io, emd3001; buffer_size=buffer_size)
                 closewrite(io)
                 seekstart(io)
                 @test read(io, MRCData) == emd3001
@@ -112,12 +112,18 @@ end
                 # with preallocation
                 io = IOBuffer(read = true, write = true)
                 buffer = Vector{Float32}(undef, buffer_size)
-                mem_prealloc = @allocated write(io, emd3001; buffer=buffer)
+                write(io, emd3001; buffer=buffer)
                 closewrite(io)
                 seekstart(io)
                 @test read(io, MRCData) == emd3001
                 close(io)
             end
         end
+    end
+
+    @testset "buffer eltype must match data type" begin
+        emd3001 = read("$(@__DIR__)/testdata/emd_3001.map", MRCData)
+        buffer = Vector{Float64}(undef, 1)
+        @test_throws ArgumentError write(IOBuffer(), emd3001; buffer=buffer)
     end
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -106,7 +106,7 @@ end
                 # no preallocation
                 io = IOBuffer(; read=true, write=true)
                 write(io, emd3001; buffer_size=buffer_size)
-                closewrite(io)
+                flush(io)
                 seekstart(io)
                 @test read(io, MRCData) == emd3001
                 close(io)
@@ -115,7 +115,7 @@ end
                 io = IOBuffer(; read=true, write=true)
                 buffer = Vector{Float32}(undef, buffer_size)
                 write(io, emd3001; buffer=buffer)
-                closewrite(io)
+                flush(io)
                 seekstart(io)
                 @test read(io, MRCData) == emd3001
                 close(io)

--- a/test/io.jl
+++ b/test/io.jl
@@ -112,7 +112,7 @@ end
                 # with preallocation
                 io = IOBuffer(read = true, write = true)
                 buffer = Vector{Float32}(undef, buffer_size)
-                mem_prealloc = @allocated write(io, emd3001; buffer)
+                mem_prealloc = @allocated write(io, emd3001; buffer=buffer)
                 closewrite(io)
                 seekstart(io)
                 @test read(io, MRCData) == emd3001


### PR DESCRIPTION
This PR extends #6 by following the suggestion of [this comment](https://github.com/sethaxen/MRC.jl/pull/6#issuecomment-746007904). Inside the `Base.write` implementation for `MRCData`, we allocate a vector of the requested size and then repeatedly write to it. This immensly decreases the memory consumption for writing. It is now also possible to provide a preallocated buffer instead.

The PR also adds some tests as suggested [here](https://github.com/sethaxen/MRC.jl/pull/6#pullrequestreview-561500952).

Finally, the `write` function previously closed the IO-stream at the end, which I think is not the expected behaviour. Now, it just finalizes the transcoding stream by writing `TranscodingStreams.TOKEN_END`.