### PR TITLE
Rename package from MRC to MRCFile

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-The MRC.jl package is licensed under the MIT "Expat" License:
+The MRCFile.jl package is licensed under the MIT "Expat" License:
 
 > Copyright (c) 2020: Seth Axen.
 >

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "MRC"
+name = "MRCFile"
 uuid = "c18c01d3-0ab9-49c3-bd2d-8f2e64a2b7a5"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
 version = "0.1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MRCFile"
 uuid = "c18c01d3-0ab9-49c3-bd2d-8f2e64a2b7a5"
-authors = ["Seth Axen <seth.axen@gmail.com>"]
+authors = ["Seth Axen <seth@sethaxen.com>"]
 version = "0.1.0"
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# MRC.jl
+# MRCFile.jl
 ![Lifecycle](https://img.shields.io/badge/lifecycle-experimental-orange.svg)
-[![Build Status](https://github.com/sethaxen/MRC.jl/workflows/CI/badge.svg)](https://github.com/sethaxen/MRC.jl/actions?query=workflow%3ACI+branch%3Amaster)
-[![Coverage](https://codecov.io/gh/sethaxen/MRC.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/sethaxen/MRC.jl)
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://sethaxen.github.io/MRC.jl/stable)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://sethaxen.github.io/MRC.jl/dev)
+[![Build Status](https://github.com/sethaxen/MRCFile.jl/workflows/CI/badge.svg)](https://github.com/sethaxen/MRCFile.jl/actions?query=workflow%3ACI+branch%3Amaster)
+[![Coverage](https://codecov.io/gh/sethaxen/MRCFile.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/sethaxen/MRCFile.jl)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://sethaxen.github.io/MRCFile.jl/stable)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://sethaxen.github.io/MRCFile.jl/dev)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 
-MRC.jl implements the [MRC2014 format](https://www.ccpem.ac.uk/mrc_format/mrc2014.php) for storing image and volume data such as those produced by electron microscopy.
+MRCFile.jl implements the [MRC2014 format](https://www.ccpem.ac.uk/mrc_format/mrc2014.php) for storing image and volume data such as those produced by electron microscopy.
 It offers the ability to read, edit, and write MRC files, as well as utility functions for extracting useful information from the headers.
 
 The key type is `MRCData`, which contains the contents of the MRC file, accessible with `header` and `extendedheader`.
@@ -15,7 +15,8 @@ The key type is `MRCData`, which contains the contents of the MRC file, accessib
 ## Installation
 
 ```julia
-] add "https://github.com/sethaxen/MRC.jl"
+using Pkg
+Pkg.add("MRCFile")
 ```
 
 ## Example
@@ -31,7 +32,7 @@ Pkg.add("Plots")
 ```
 
 ```julia
-using MRC, FTPClient, Plots
+using MRCFile, FTPClient, Plots
 
 emdid = 5778 # TRPV1
 ftp = FTP(hostname = "ftp.rcsb.org/pub/emdb/structures/EMD-$(emdid)/map")
@@ -47,7 +48,7 @@ end
 gif(anim, "emd-$(emdid)_slices.gif", fps = 30)
 ```
 
-![EMD-5778 slices](https://github.com/sethaxen/MRC.jl/blob/master/docs/src/assets/emd-5778_slices.gif)
+![EMD-5778 slices](https://github.com/sethaxen/MRCFile.jl/blob/master/docs/src/assets/emd-5778_slices.gif)
 
 # Reading a map as a memory-mapped array
 
@@ -56,7 +57,7 @@ It is convenient then to load their data as [memory-mapped arrays](https://docs.
 This is easy to do:
 
 ```julia
-using MRC
+using MRCFile
 
 path = "mymap.mrc" # path to large uncompressed MRC file
 mrc = read_mmap(path, MRCData)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,16 +1,16 @@
-using MRC
+using MRCFile
 using Documenter
 
 makedocs(;
-    modules=[MRC],
+    modules=[MRCFile],
     authors="Seth Axen <seth.axen@gmail.com> and contributors",
-    sitename="MRC.jl",
+    sitename="MRCFile.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://sethaxen.github.io/MRC.jl",
+        canonical="https://sethaxen.github.io/MRCFile.jl",
         assets=String[],
     ),
     pages=["Home" => "index.md", "API" => "api.md"],
 )
 
-deploydocs(; repo="github.com/sethaxen/MRC.jl")
+deploydocs(; repo="github.com/sethaxen/MRCFile.jl")

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,7 +1,7 @@
 # API
 
 ```@autodocs
-Modules = [MRC]
+Modules = [MRCFile]
 Private = false
 Order = [:type, :function]
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
-# MRC
+# MRCFile
 
-MRC.jl implements the [MRC2014 format](https://www.ccpem.ac.uk/mrc_format/mrc2014.php) for storing image and volume data such as those produced by electron microscopy.
+MRCFile.jl implements the [MRC2014 format](https://www.ccpem.ac.uk/mrc_format/mrc2014.php) for storing image and volume data such as those produced by electron microscopy.
 It offers the ability to read, edit, and write MRC files, as well as utility functions for extracting useful information from the headers.
 
 The key type is `MRCData`, which contains the contents of the MRC file, accessible with `header` and `extendedheader`.

--- a/src/MRCFile.jl
+++ b/src/MRCFile.jl
@@ -1,4 +1,4 @@
-module MRC
+module MRCFile
 
 using Dates, Statistics, Mmap, CodecZlib, CodecBzip2, CodecXz, TranscodingStreams
 

--- a/src/header.jl
+++ b/src/header.jl
@@ -73,7 +73,7 @@ function MRCHeader(; kwargs...)
         -1, # rms < 0 means rms is undetermined
         1, # nlabl
         (
-            "Created by MRC.jl at $(Dates.format(now(), "yyyy-mm-dd HH:MM:SS"))",
+            "Created by MRCFile.jl at $(Dates.format(now(), "yyyy-mm-dd HH:MM:SS"))",
             ntuple(_ -> "", Val(9))...,
         ), # label
     )

--- a/test/header.jl
+++ b/test/header.jl
@@ -32,12 +32,12 @@
         @test h.origin_y === Float32(0)
         @test h.origin_z === Float32(0)
         @test h.map === "MAP "
-        @test h.machst === Tuple(MRC.machstfrombyteorder())
+        @test h.machst === Tuple(MRCFile.machstfrombyteorder())
         @test h.rms === Float32(-1)
         @test h.nlabl === Int32(1)
         @test length(h.label) == 10
         @test length(h.label[1]) < 80
-        @test startswith(h.label[1], "Created by MRC.jl at ")
+        @test startswith(h.label[1], "Created by MRCFile.jl at ")
     end
 
     @testset "MRCHeader(kwargs...)" begin
@@ -119,24 +119,24 @@ end
     (:testint, Int32, sizeof(Int32)),
     (:testuintbool, NTuple{8,UInt8}, sizeof(NTuple{8,UInt8})),
 )
-    @test MRC.sizeoffield(name, type) == s
+    @test MRCFile.sizeoffield(name, type) == s
 end
 
 @testset "entrytobytes" begin
-    @test MRC.entrytobytes(:exttyp, "abc") == [0x61, 0x62, 0x63, 0x00]
-    @test MRC.entrytobytes(:exttyp, "abcde") == [0x61, 0x62, 0x63, 0x64]
-    @test MRC.entrytobytes(:map, "abc") == [0x61, 0x62, 0x63, 0x00]
-    @test MRC.entrytobytes(:map, "abcde") == [0x61, 0x62, 0x63, 0x64]
-    @test MRC.entrytobytes(:label, ("abcd", ntuple(_ -> "", 9)...))[1:80] ==
+    @test MRCFile.entrytobytes(:exttyp, "abc") == [0x61, 0x62, 0x63, 0x00]
+    @test MRCFile.entrytobytes(:exttyp, "abcde") == [0x61, 0x62, 0x63, 0x64]
+    @test MRCFile.entrytobytes(:map, "abc") == [0x61, 0x62, 0x63, 0x00]
+    @test MRCFile.entrytobytes(:map, "abcde") == [0x61, 0x62, 0x63, 0x64]
+    @test MRCFile.entrytobytes(:label, ("abcd", ntuple(_ -> "", 9)...))[1:80] ==
         [0x61; 0x62; 0x63; 0x64; zeros(UInt8, 76)]
-    @test MRC.entrytobytes(:testfloat, Float32(3)) == reinterpret(UInt8, [Float32(3)])
-    @test MRC.entrytobytes(:testint, Int32(3)) == reinterpret(UInt8, [Int32(3)])
-    @test MRC.entrytobytes(:testuintbool, (0x01, 0x02, 0x03, 0x04)) ==
+    @test MRCFile.entrytobytes(:testfloat, Float32(3)) == reinterpret(UInt8, [Float32(3)])
+    @test MRCFile.entrytobytes(:testint, Int32(3)) == reinterpret(UInt8, [Int32(3)])
+    @test MRCFile.entrytobytes(:testuintbool, (0x01, 0x02, 0x03, 0x04)) ==
         [0x01, 0x02, 0x03, 0x04]
 end
 
 @testset "fieldoffsets" begin
-    @test MRC.fieldoffsets(MRCHeader) == [
+    @test MRCFile.fieldoffsets(MRCHeader) == [
         0,
         4,
         8,

--- a/test/io.jl
+++ b/test/io.jl
@@ -11,7 +11,7 @@
             @test h.nx === Int32(size(p)[1]) === Int32(73)
             @test h.ny === Int32(size(p)[2]) === Int32(43)
             @test h.nz === Int32(size(p)[3]) === Int32(25)
-            @test MRC.datatype(h.mode) === eltype(p) === Float32
+            @test MRCFile.datatype(h.mode) === eltype(p) === Float32
             @test h.nxstart === Int32(0)
             @test h.nystart === Int32(-21)
             @test h.nzstart === Int32(-12)
@@ -39,7 +39,7 @@
             @test h.origin_x === Float32(0)
             @test h.origin_y === Float32(0)
             @test h.origin_z === Float32(0)
-            @test h.map === MRC.MAP_NAME
+            @test h.map === MRCFile.MAP_NAME
             @test h.machst === (0x44, 0x41, 0x0, 0x0)
             @test h.rms === Float32(0.15705723)
             @test h.nlabl === Int32(1)
@@ -58,7 +58,7 @@
             @test h.nx === Int32(size(p)[1]) === Int32(20)
             @test h.ny === Int32(size(p)[2]) === Int32(20)
             @test h.nz === Int32(size(p)[3]) === Int32(20)
-            @test MRC.datatype(h.mode) === eltype(p) === Float32
+            @test MRCFile.datatype(h.mode) === eltype(p) === Float32
             @test h.nxstart === Int32(-2)
             @test h.nystart === Int32(0)
             @test h.nzstart === Int32(0)
@@ -86,7 +86,7 @@
             @test h.origin_x === Float32(0)
             @test h.origin_y === Float32(0)
             @test h.origin_z === Float32(0)
-            @test h.map === MRC.MAP_NAME
+            @test h.map === MRCFile.MAP_NAME
             @test h.machst === (0x44, 0x41, 0x0, 0x0)
             @test h.rms === Float32(2.399953)
             @test h.nlabl === Int32(1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
-using MRC, TranscodingStreams
+using MRCFile, TranscodingStreams
 using Test
 
-@testset "MRC.jl" begin
+@testset "MRCFile.jl" begin
     include("utils.jl")
     include("header.jl")
     include("io.jl")

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,88 +1,88 @@
 @testset "hostbyteorder" begin
     if Base.ENDIAN_BOM == 0x04030201
-        @test MRC.hostbyteorder() == MRC.LittleEndian
+        @test MRCFile.hostbyteorder() == MRCFile.LittleEndian
     else
-        @test MRC.hostbyteorder() == MRC.BigEndian
+        @test MRCFile.hostbyteorder() == MRCFile.BigEndian
     end
 end
 
 @testset "machstfrombyteorder" begin
-    @test MRC.machstfrombyteorder() == [0x44, 0x44, 0x00, 0x00]
-    @test MRC.machstfrombyteorder(MRC.LittleEndian) == [0x44, 0x44, 0x00, 0x00]
-    @test MRC.machstfrombyteorder(MRC.BigEndian) == [0x11, 0x11, 0x00, 0x00]
+    @test MRCFile.machstfrombyteorder() == [0x44, 0x44, 0x00, 0x00]
+    @test MRCFile.machstfrombyteorder(MRCFile.LittleEndian) == [0x44, 0x44, 0x00, 0x00]
+    @test MRCFile.machstfrombyteorder(MRCFile.BigEndian) == [0x11, 0x11, 0x00, 0x00]
 end
 
 @testset "byteorderfrommachst" begin
-    @test MRC.byteorderfrommachst([0x44, 0x44, 0x00, 0x00]) == MRC.LittleEndian
-    @test MRC.byteorderfrommachst([0x44, 0x41, 0x00, 0x00]) == MRC.LittleEndian
-    @test MRC.byteorderfrommachst([0x11, 0x11, 0x00, 0x00]) == MRC.BigEndian
+    @test MRCFile.byteorderfrommachst([0x44, 0x44, 0x00, 0x00]) == MRCFile.LittleEndian
+    @test MRCFile.byteorderfrommachst([0x44, 0x41, 0x00, 0x00]) == MRCFile.LittleEndian
+    @test MRCFile.byteorderfrommachst([0x11, 0x11, 0x00, 0x00]) == MRCFile.BigEndian
     @test (@test_logs (
         :warn,
         "Unrecognized machine stamp $([0x00, 0x00, 0x00, 0x00]). Assuming little endian.",
-    ) MRC.byteorderfrommachst([0x00, 0x00, 0x00, 0x00])) == MRC.LittleEndian
+    ) MRCFile.byteorderfrommachst([0x00, 0x00, 0x00, 0x00])) == MRCFile.LittleEndian
 end
 
 @testset "bswaptoh" begin
-    @test MRC.bswaptoh(MRC.LittleEndian) == MRC.maybeswap(ltoh)
-    @test MRC.bswaptoh(MRC.MACHINE_STAMP_LITTLE) == MRC.maybeswap(ltoh)
-    @test MRC.bswaptoh(MRC.MACHINE_STAMP_LITTLE_ALT) == MRC.maybeswap(ltoh)
-    @test MRC.bswaptoh(MRC.BigEndian) == MRC.maybeswap(ntoh)
-    @test MRC.bswaptoh(MRC.MACHINE_STAMP_BIG) == MRC.maybeswap(ntoh)
+    @test MRCFile.bswaptoh(MRCFile.LittleEndian) == MRCFile.maybeswap(ltoh)
+    @test MRCFile.bswaptoh(MRCFile.MACHINE_STAMP_LITTLE) == MRCFile.maybeswap(ltoh)
+    @test MRCFile.bswaptoh(MRCFile.MACHINE_STAMP_LITTLE_ALT) == MRCFile.maybeswap(ltoh)
+    @test MRCFile.bswaptoh(MRCFile.BigEndian) == MRCFile.maybeswap(ntoh)
+    @test MRCFile.bswaptoh(MRCFile.MACHINE_STAMP_BIG) == MRCFile.maybeswap(ntoh)
 end
 
 @testset "bswapfromh" begin
-    @test MRC.bswapfromh(MRC.LittleEndian) == MRC.maybeswap(htol)
-    @test MRC.bswapfromh(MRC.MACHINE_STAMP_LITTLE) == MRC.maybeswap(htol)
-    @test MRC.bswapfromh(MRC.MACHINE_STAMP_LITTLE_ALT) == MRC.maybeswap(htol)
-    @test MRC.bswapfromh(MRC.BigEndian) == MRC.maybeswap(hton)
-    @test MRC.bswapfromh(MRC.MACHINE_STAMP_BIG) == MRC.maybeswap(hton)
+    @test MRCFile.bswapfromh(MRCFile.LittleEndian) == MRCFile.maybeswap(htol)
+    @test MRCFile.bswapfromh(MRCFile.MACHINE_STAMP_LITTLE) == MRCFile.maybeswap(htol)
+    @test MRCFile.bswapfromh(MRCFile.MACHINE_STAMP_LITTLE_ALT) == MRCFile.maybeswap(htol)
+    @test MRCFile.bswapfromh(MRCFile.BigEndian) == MRCFile.maybeswap(hton)
+    @test MRCFile.bswapfromh(MRCFile.MACHINE_STAMP_BIG) == MRCFile.maybeswap(hton)
 end
 
 @testset "maybeswap" begin
-    @test MRC.maybeswap(bswap, Int32(5)) === bswap(Int32(5))
-    @test MRC.maybeswap(bswap, "foo") === "foo"
-    @test MRC.maybeswap(bswap, (Int32(5), Int32(6))) === (bswap(Int32(5)), bswap(Int32(6)))
-    @test MRC.maybeswap(bswap, (0x01, 0x02)) === (0x01, 0x02)
-    @test MRC.maybeswap(bswap)(Int32(5)) === bswap(Int32(5))
+    @test MRCFile.maybeswap(bswap, Int32(5)) === bswap(Int32(5))
+    @test MRCFile.maybeswap(bswap, "foo") === "foo"
+    @test MRCFile.maybeswap(bswap, (Int32(5), Int32(6))) === (bswap(Int32(5)), bswap(Int32(6)))
+    @test MRCFile.maybeswap(bswap, (0x01, 0x02)) === (0x01, 0x02)
+    @test MRCFile.maybeswap(bswap)(Int32(5)) === bswap(Int32(5))
 end
 
 @testset "padtruncto!" begin
     x = [1, 2, 3]
-    MRC.padtruncto!(x, 4)
+    MRCFile.padtruncto!(x, 4)
     @test x == [1, 2, 3, 0]
-    MRC.padtruncto!(x, 6; value=1)
+    MRCFile.padtruncto!(x, 6; value=1)
     @test x == [1, 2, 3, 0, 1, 1]
-    MRC.padtruncto!(x, 3)
+    MRCFile.padtruncto!(x, 3)
     @test x == [1, 2, 3]
-    MRC.padtruncto!(x, 5; value=1.0)
+    MRCFile.padtruncto!(x, 5; value=1.0)
     @test x == [1, 2, 3, 1, 1]
 end
 
-@testset "compression: $type" for type in keys(MRC.COMPRESSIONS)
-    spec = getproperty(MRC.COMPRESSIONS, type)
+@testset "compression: $type" for type in keys(MRCFile.COMPRESSIONS)
+    spec = getproperty(MRCFile.COMPRESSIONS, type)
     @testset "checkmagic" begin
         io = IOBuffer()
         write(io, spec.magic)
         write(io, [0x01, 0x02, 0x03])
         seek(io, 0)
-        type2 = MRC.checkmagic(io)
+        type2 = MRCFile.checkmagic(io)
         @test type2 == type
         close(io)
     end
 
     @testset "checkextension" begin
         fn = "map.mrc$(spec.extension)"
-        type2 = MRC.checkextension(fn)
+        type2 = MRCFile.checkextension(fn)
         @test type2 == type
     end
 
     @testset "(de)compressstream" begin
         buf = IOBuffer()
-        stream = MRC.compressstream(buf, type)
+        stream = MRCFile.compressstream(buf, type)
         write(stream, b"foo", TranscodingStreams.TOKEN_END)
         newbuf = IOBuffer(take!(buf))
-        @test MRC.checkmagic(newbuf) == type
-        newstream = MRC.decompressstream(newbuf, type)
+        @test MRCFile.checkmagic(newbuf) == type
+        newstream = MRCFile.decompressstream(newbuf, type)
         @test read(newstream) == b"foo"
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -41,7 +41,8 @@ end
 @testset "maybeswap" begin
     @test MRCFile.maybeswap(bswap, Int32(5)) === bswap(Int32(5))
     @test MRCFile.maybeswap(bswap, "foo") === "foo"
-    @test MRCFile.maybeswap(bswap, (Int32(5), Int32(6))) === (bswap(Int32(5)), bswap(Int32(6)))
+    @test MRCFile.maybeswap(bswap, (Int32(5), Int32(6))) ===
+        (bswap(Int32(5)), bswap(Int32(6)))
     @test MRCFile.maybeswap(bswap, (0x01, 0x02)) === (0x01, 0x02)
     @test MRCFile.maybeswap(bswap)(Int32(5)) === bswap(Int32(5))
 end


### PR DESCRIPTION
This name is more descriptive, more easily searchable, and follows Julia's package naming guidelines.