### PR TITLE
style: format code with JuliaFormatter

### DIFF
--- a/ext/DimensionalDataExt.jl
+++ b/ext/DimensionalDataExt.jl
@@ -25,6 +25,6 @@ function DimArray(mrc::MRCData)
         (X, Y, Z)[h.maps](axs[3]),
     )
     #! format: on
-    DimArray(mrc.data, dimaxs)
+    return DimArray(mrc.data, dimaxs)
 end
 end

--- a/test/dimensionaldata.jl
+++ b/test/dimensionaldata.jl
@@ -15,7 +15,7 @@ using DimensionalData
                     X = At(axs.x[idcs.x]), Y = At(axs.y[idcs.y]), Z = At(axs.z[idcs.z])
                 ]
                 right = mrc.data[ci]
-                left == right
+                return left == right
             end
         end
     end


### PR DESCRIPTION
Fixes failing Format CI check — missing explicit `return` statements per newer JuliaFormatter.