### PR TITLE
ci: fix docs deploy race condition

### DIFF
--- a/.github/workflows/.documenter.yml
+++ b/.github/workflows/.documenter.yml
@@ -5,6 +5,10 @@ on:
     tags: [v*]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   docs:
     name: Documentation
@@ -15,7 +19,6 @@ jobs:
         with:
           version: '1'
       - uses: julia-actions/julia-docdeploy@releases/v1
-      - run: julia --project=docs docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
Docs deploy has been intermittently failing with `failed to push some refs to gh-pages`. Root cause: `julia-docdeploy` had no env vars attached so it silently skipped deploying, while a redundant manual `docs/make.jl` step (which did have GITHUB_TOKEN/DOCUMENTER_KEY) did the real deploy — and with no concurrency group, two docs jobs from quick successive pushes race to push gh-pages. This moves the creds onto the docdeploy step, removes the now-redundant manual step, and adds a concurrency group so overlapping runs queue instead of racing.