### PR TITLE
ci: modernize TagBot workflow

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -13,3 +13,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}
+          changelog_format: conventional


### PR DESCRIPTION
Update `.github/workflows/TagBot.yml` to the current recommended template: drop the deprecated `lookback` input and the `permissions` block, and add `changelog_format: conventional` since this repo uses Conventional Commits.